### PR TITLE
More handling of sensitive/spoiler/nsfw posts

### DIFF
--- a/doc/HELP.md
+++ b/doc/HELP.md
@@ -38,6 +38,8 @@ These settings will affect Mastodon accounts:
 * *set show_ids* - display the "id" in front of every message
 * *set target_url_length* - an URL counts as 23 characters
 * *set name* - the name for your account channel
+* *set hide_sensitive* - hide content marked as sensitive by the author
+* *set sensitive_flag* - text to flag sensitive content with; default "*NSFW* "
 
 ## set name
 *Type:* string  

--- a/doc/mastodon-help.txt
+++ b/doc/mastodon-help.txt
@@ -36,6 +36,8 @@ These settings will affect Mastodon accounts:
  set show_ids - display the "id" in front of every message
  set target_url_length - an URL counts as 23 characters
  set name - the name for your account channel
+ set hide_sensitive - hide content marked as sensitive by the author
+ set sensitive_flag - text to flag sensitive content with; default "*NSFW* "
 %
 ?set name
 Type: string

--- a/src/mastodon-lib.c
+++ b/src/mastodon-lib.c
@@ -533,7 +533,6 @@ static struct mastodon_status *mastodon_xt_get_status(const json_value *node, st
 		if (nsfw) {
 			char *sensitive_flag = set_getstr(&ic->acc->set, "sensitive_flag");
 			g_string_append(s, sensitive_flag);
-			g_string_append(s, " ");
 		}
 
 		if (text_value) {

--- a/src/mastodon-lib.c
+++ b/src/mastodon-lib.c
@@ -404,7 +404,7 @@ void mastodon_strip_html(char *in)
 /**
  * Function to fill a mastodon_status struct.
  */
-static struct mastodon_status *mastodon_xt_get_status(const json_value *node)
+static struct mastodon_status *mastodon_xt_get_status(const json_value *node, struct im_connection *ic)
 {
 	struct mastodon_status *ms = {0};
 	const json_value *rt = NULL;
@@ -504,7 +504,7 @@ static struct mastodon_status *mastodon_xt_get_status(const json_value *node)
 	}
 
 	if (rt) {
-		struct mastodon_status *rms = mastodon_xt_get_status(rt);
+		struct mastodon_status *rms = mastodon_xt_get_status(rt, ic);
 		if (rms) {
 			/* Alternatively, we could free ms and just use rms, but we'd have to overwrite rms->account
 			 * with ms->account, change rms->text, and maybe more. */
@@ -531,7 +531,9 @@ static struct mastodon_status *mastodon_xt_get_status(const json_value *node)
 		}
 
 		if (nsfw) {
-			g_string_append(s, "*NSFW* ");
+			char *sensitive_flag = set_getstr(&ic->acc->set, "sensitive_flag");
+			g_string_append(s, sensitive_flag);
+			g_string_append(s, " ");
 		}
 
 		if (text_value) {
@@ -572,7 +574,7 @@ static struct mastodon_status *mastodon_xt_get_status(const json_value *node)
 /**
  * Function to fill a mastodon_notification struct.
  */
-static struct mastodon_notification *mastodon_xt_get_notification(const json_value *node)
+static struct mastodon_notification *mastodon_xt_get_notification(const json_value *node, struct im_connection *ic)
 {
 	if (node->type != json_object) {
 		return FALSE;
@@ -595,7 +597,7 @@ static struct mastodon_notification *mastodon_xt_get_notification(const json_val
 		} else if (strcmp("account", k) == 0 && v->type == json_object) {
 			mn->account = mastodon_xt_get_user(v);
 		} else if (strcmp("status", k) == 0 && v->type == json_object) {
-			mn->status = mastodon_xt_get_status(v);
+			mn->status = mastodon_xt_get_status(v, ic);
 		} else if (strcmp("type", k) == 0 && v->type == json_string) {
 			if (strcmp(v->u.string.ptr, "mention") == 0) {
 				mn->type = MN_MENTION;
@@ -628,7 +630,7 @@ static gboolean mastodon_xt_get_status_list(struct im_connection *ic, const json
 
 	int i;
 	for (i = 0; i < node->u.array.length; i++) {
-		struct mastodon_status *ms = mastodon_xt_get_status(node->u.array.values[i]);
+		struct mastodon_status *ms = mastodon_xt_get_status(node->u.array.values[i], ic);
 		if (ms) {
 			ml->list = g_slist_prepend(ml->list, ms);
 		}
@@ -648,7 +650,7 @@ static gboolean mastodon_xt_get_notification_list(struct im_connection *ic, cons
 
 	int i;
 	for (i = 0; i < node->u.array.length; i++) {
-		struct mastodon_notification *mn = mastodon_xt_get_notification(node->u.array.values[i]);
+		struct mastodon_notification *mn = mastodon_xt_get_notification(node->u.array.values[i], ic);
 		if (mn) {
 			ml->list = g_slist_prepend(ml->list, mn);
 		}
@@ -940,7 +942,7 @@ static void mastodon_notification_show(struct im_connection *ic, struct mastodon
  */
 static void mastodon_stream_handle_notification(struct im_connection *ic, json_value *parsed)
 {
-	struct mastodon_notification *mn = mastodon_xt_get_notification(parsed);
+	struct mastodon_notification *mn = mastodon_xt_get_notification(parsed, ic);
 	if (mn) {
 		mastodon_notification_show(ic, mn);
 		mn_free(mn);
@@ -952,7 +954,7 @@ static void mastodon_stream_handle_notification(struct im_connection *ic, json_v
  */
 static void mastodon_stream_handle_update(struct im_connection *ic, json_value *parsed, mastodon_timeline_type_t subscription)
 {
-	struct mastodon_status *ms = mastodon_xt_get_status(parsed);
+	struct mastodon_status *ms = mastodon_xt_get_status(parsed, ic);
 	if (ms) {
 		ms->subscription = subscription;
 		mastodon_status_show(ic, ms);
@@ -1176,7 +1178,7 @@ static void mastodon_http_timeline(struct http_request *req, mastodon_timeline_t
 	int i;
 	for (i = parsed->u.array.length - 1; i >= 0 ; i--) {
 		json_value *node = parsed->u.array.values[i];
-		struct mastodon_status *ms = mastodon_xt_get_status(node);
+		struct mastodon_status *ms = mastodon_xt_get_status(node, ic);
 		ms->subscription = subscription;
 		mastodon_status_show(ic, ms);
 		ms_free(ms);
@@ -1428,7 +1430,7 @@ static void mastodon_http_callback(struct http_request *req)
 	case MC_UNKNOWN:
 		break;
 	case MC_POST:
-		ms = mastodon_xt_get_status(parsed);
+		ms = mastodon_xt_get_status(parsed, ic);
 		if (ms && ms->id && strcmp(ms->account->acct, md->user) == 0) {
 			md->last_id = ms->id;
 			if(md->undo_type == MASTODON_NEW) {
@@ -1755,7 +1757,7 @@ void mastodon_http_status_delete(struct http_request *req)
 	}
 
 	/* Remember the text  */
-	struct mastodon_status *ms = mastodon_xt_get_status(parsed);
+	struct mastodon_status *ms = mastodon_xt_get_status(parsed, ic);
 	struct mastodon_data *md = ic->proto_data;
 	if (ms && ms->id && strcmp(ms->account->acct, md->user) == 0) {
 		md->last_id = ms->id;
@@ -1841,7 +1843,7 @@ void mastodon_http_report(struct http_request *req)
 		goto finally;
 	}
 
-	struct mastodon_status *ms = mastodon_xt_get_status(parsed);
+	struct mastodon_status *ms = mastodon_xt_get_status(parsed, ic);
 	if (ms) {
 		mr->account_id = ms->account->id;
 		ms_free(ms);
@@ -2023,7 +2025,7 @@ static void mastodon_http_status_show_url(struct http_request *req)
 		return;
 	}
 
-	struct mastodon_status *ms = mastodon_xt_get_status(parsed);
+	struct mastodon_status *ms = mastodon_xt_get_status(parsed, ic);
 	if (ms) {
 		mastodon_log(ic, ms->url);
 		ms_free(ms);
@@ -2061,7 +2063,7 @@ static void mastodon_http_status_show_mentions(struct http_request *req)
 		return;
 	}
 
-	struct mastodon_status *ms = mastodon_xt_get_status(parsed);
+	struct mastodon_status *ms = mastodon_xt_get_status(parsed, ic);
 	if (ms) {
 		if (ms->mentions) {
 			GString *s = g_string_new("");
@@ -2204,7 +2206,7 @@ void mastodon_http_context_status(struct http_request *req)
 		goto end;
 	}
 
-	md->status_obj = mastodon_xt_get_status(parsed);
+	md->status_obj = mastodon_xt_get_status(parsed, ic);
 
 	json_value_free(parsed);
 end:

--- a/src/mastodon-lib.c
+++ b/src/mastodon-lib.c
@@ -536,7 +536,16 @@ static struct mastodon_status *mastodon_xt_get_status(const json_value *node, st
 		}
 
 		if (text_value) {
-			g_string_append(s, text_value->u.string.ptr);
+			if (nsfw && set_getbool(&ic->acc->set, "hide_sensitive")) {
+				g_string_append(s, "[hidden");
+				if (ms->url) {
+					g_string_append(s, ": ");
+					g_string_append(s, ms->url);
+				}
+				g_string_append(s, "]");
+			} else {
+				g_string_append(s, text_value->u.string.ptr);
+			}
 		}
 
 		GSList *l = NULL;

--- a/src/mastodon.c
+++ b/src/mastodon.c
@@ -249,7 +249,7 @@ static void mastodon_init(account_t * acc)
 
 	s = set_add(&acc->set, "strip_newlines", "false", set_eval_bool, acc);
 
-	s = set_add(&acc->set, "sensitive_flag", "*NSFW*", NULL, acc);
+	s = set_add(&acc->set, "sensitive_flag", "*NSFW* ", NULL, acc);
 
 	s = set_add(&acc->set, "app_id", "0", set_eval_int, acc);
 	s->flags |= SET_HIDDEN;

--- a/src/mastodon.c
+++ b/src/mastodon.c
@@ -249,6 +249,8 @@ static void mastodon_init(account_t * acc)
 
 	s = set_add(&acc->set, "strip_newlines", "false", set_eval_bool, acc);
 
+	s = set_add(&acc->set, "hide_sensitive", "false", set_eval_bool, acc);
+
 	s = set_add(&acc->set, "sensitive_flag", "*NSFW* ", NULL, acc);
 
 	s = set_add(&acc->set, "app_id", "0", set_eval_int, acc);

--- a/src/mastodon.c
+++ b/src/mastodon.c
@@ -249,6 +249,8 @@ static void mastodon_init(account_t * acc)
 
 	s = set_add(&acc->set, "strip_newlines", "false", set_eval_bool, acc);
 
+	s = set_add(&acc->set, "sensitive_flag", "*NSFW*", NULL, acc);
+
 	s = set_add(&acc->set, "app_id", "0", set_eval_int, acc);
 	s->flags |= SET_HIDDEN;
 


### PR DESCRIPTION
Hi @kensanata,

I've added a couple of extra settings to allow customisable handling of posts marked as sensitive by their author. Recently I've seen this used for posting spoilers so the content can be entirely hidden in such situations. I've also added customising of the *NSFW* text, since it's not always used for nsfw content. (It also means you can set it to a colour code like ^C5 which creates a pleasant display.)

What do you think?
![masto](https://user-images.githubusercontent.com/450243/40863472-e227b48c-65e7-11e8-9eb6-3bce964bf6b4.png)
