### PR TITLE
Check cw isn't NULL before g_utf8_strlen

### DIFF
--- a/src/mastodon.c
+++ b/src/mastodon.c
@@ -161,7 +161,9 @@ static gboolean mastodon_length_check(struct im_connection *ic, gchar *msg, char
 		return FALSE;
 	}
 
-	len+= g_utf8_strlen(cw, -1);
+	if (cw != NULL) {
+		len += g_utf8_strlen(cw, -1);
+	}
 
 	int max = set_getint(&ic->acc->set, "message_length");
 	if (max == 0) {


### PR DESCRIPTION
Avoids the following glib warning being dumped to stderr (or apparently the control channel if bitlbee's deployed in inetd mode):

(process:9444): GLib-CRITICAL **: 17:45:02.925: g_utf8_strlen: assertion 'p != NULL || max == 0' failed
