### PR TITLE
determine server to connect to by parsing username at account creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,7 @@ AS_IF(
 )
 
 AC_SUBST([datadir])
+AC_SUBST([ac_cv_path_SED])
 
 AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile])
 AC_OUTPUT

--- a/doc/HELP.md
+++ b/doc/HELP.md
@@ -32,6 +32,8 @@ Mastodon is a free, open-source social network server. A decentralized solution 
 ## news
 Use **plugins** in the control channel (**&bitlbee**) to learn which version of the plugin you have.
 
+Incompatible change in **1.4.3**: The URL path is ignored in the base URL (such that we can use /api/v2/search).
+
 Incompatible change in **1.4.0**: If you have subscribed to a hashtag, you need to change your channel settings and prepend the hash. Do this from the control channel (**&bitlbee**). Let's assume you have a channel called #hashtag. It's **room** setting should be **#hashtag**. If it's lacking the initial hash:
 
 > **&lt;kensanata&gt;** channel #hashtag set room  

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -30,7 +30,7 @@ install-data-local:
 	fi
 
 HELP.md: mastodon-help.txt Makefile
-	sed \
+	@ac_cv_path_SED@ \
 	-e '1i# Bitlbee Mastodon\nThis document was generated from the help text for the plugin.\n' \
 	-e '1d' \
 	-e 's/^%$$//g' \

--- a/src/mastodon-lib.c
+++ b/src/mastodon-lib.c
@@ -38,6 +38,7 @@
 #include "base64.h"
 #include "mastodon-lib.h"
 #include "oauth2.h"
+#include "json.h"
 #include "json_util.h"
 #include <assert.h>
 #include <ctype.h>
@@ -2560,7 +2561,7 @@ void mastodon_http_search(struct http_request *req)
 		for (i = 0; i < v->u.array.length; i++) {
 			json_value *a;
 			a = v->u.array.values[i];
-			if ((a->type == json_object)) {
+			if (a->type == json_object) {
 				mastodon_log(ic, "@%s %s",
 					     json_o_str(a, "acct"),
 					     json_o_str(a, "display_name"));
@@ -3658,6 +3659,7 @@ void mastodon_http_list_delete2(struct http_request *req) {
 	goto success;
 finish:
 	mc_free(mc);
+	return;
 success:
 	json_value_free(parsed);
 }

--- a/src/mastodon-lib.h
+++ b/src/mastodon-lib.h
@@ -27,11 +27,10 @@
 #include "nogaim.h"
 #include "mastodon-http.h"
 
-#define MASTODON_API_URL "https://octodon.social"
-
 // "2017-08-02T10:45:03.000Z" -- but we're ignoring microseconds and UTC timezone
 #define MASTODON_TIME_FORMAT "%Y-%m-%dT%H:%M:%S"
 
+#define MASTODON_API_ENDPOINT "/api/v1"
 #define MASTODON_REGISTER_APP_URL "/api/v1/apps"
 #define MASTODON_VERIFY_CREDENTIALS_URL "/api/v1/accounts/verify_credentials"
 #define MASTODON_STREAMING_USER_URL "/api/v1/streaming/user"

--- a/src/mastodon.h
+++ b/src/mastodon.h
@@ -34,7 +34,7 @@
 #endif
 
 #define MASTODON_OAUTH_HANDLE "mastodon_oauth"
-#define MASTODON_SCOPE "read%20write%20follow" // URL escaped
+#define MASTODON_SCOPE "read+write+follow" // URL escaped
 #define MASTODON_URL_REGEX "https?://\\S+"
 #define MASTODON_MENTION_REGEX "@(([a-zA-Z0-9_]+)@[a-zA-Z0-9.-]+[a-zA-Z0-9])"
 


### PR DESCRIPTION
the primary purpose of this PR is to address #36 from a UI perspective and make account creation behave as expected. it does this by attempting to decode the "username" passed at account creation as a fediverse handle (either in the Mastodon `@user@instance` format or the pleroma `user@instance` format), and setting the `base_url` and `username` fields appropriately. if there is no `@` sign after the username portion of the handle, we assume the user is connecting to the flagship mastodon instance `https://mastodon.social`, which is kind of awful but unfortunately the bitlbee plugin API does not appear to give us a way to abort the account creation and signal an error to the user.

this PR also resolves a number of compiler warnings:

- instead of hardcoding a reference to `sed`, `doc/Makefile.am` uses the appropriate autotools variable to determine which `sed` to use. this is necessary because the `sed` scripts used in that makefile use GNU-only extensions, and `sed` on BSDs is generally not GNU sed. partially resolves #38.
- certain code paths led to the `parsed` variable in `src/mastodon-lib.c` being passed uninitialized to bitlbee's `json_value_free`, which could wreak all sorts of havoc and will almost certainly prevent segfaults or worse going forward.
- unnecessary parentheses that were causing a compiler warning were removed.