### PR TITLE
Support BSD make and sed

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -30,17 +30,19 @@ install-data-local:
 	fi
 
 HELP.md: mastodon-help.txt Makefile
-	@ac_cv_path_SED@ \
-	-e '1i# Bitlbee Mastodon\nThis document was generated from the help text for the plugin.\n' \
-	-e '1d' \
-	-e 's/^%$$//g' \
-	-e 's/^\?mastodon /## /g' \
-	-e 's/^\?/## /g' \
-	-e 's/\*/\\*/g' \
-	-e 's//**/g' \
-	-e 's/^ \*/* */g' \
-	-e 's/\*help mastodon \([a-z]*2*\)\*/[\1](#\1)/g' \
-	-e 's/</\&lt;/g' \
-	-e 's/>/\&gt;/g' \
-	-e 's/^\(\*[^ ].*\)/> \1  /g' \
-	< $< > $@
+	(echo '# Bitlbee Mastodon'; \
+echo 'This document was generated from the help text for the plugin.'; \
+echo ''; \
+@ac_cv_path_SED@ \
+-e '1d' \
+-e 's/^%$$//g' \
+-e 's/^\?mastodon /## /g' \
+-e 's/^\?/## /g' \
+-e 's/\*/\\*/g' \
+-e 's//**/g' \
+-e 's/^ \*/* */g' \
+-e 's/\*help mastodon \([a-z]*2*\)\*/[\1](#\1)/g' \
+-e 's/</\&lt;/g' \
+-e 's/>/\&gt;/g' \
+-e 's/^\(\*[^ ].*\)/> \1  /g') \
+< mastodon-help.txt > $@


### PR DESCRIPTION
Commit bd55931 added a sed command to generate doc/HELP.md. Both the
sed command and the Makefile syntax don't play well with FreeBSD's
non-GNU make and sed.

BSD make doesn't recognize $<. When run, this error is produced:

    /bin/sh: Syntax error: redirection unexpected (expecting word)

I changed the Makefile to instead use an explicit target.

Once that was fixed, another error showed up:

    sed: 1: "1i# Bitlbee Mastodon\nT ...": command i expects \ followed by text

I believe this is due to GNU sed allowing an alternate syntax that the
original sed did not. To get around this I removed the insert commands
from sed and instead emit the header separately. I also switched from
using a big make command to a big shell command run in a redirected
subshell. I could have used multiple make commands but this way the
output file only needed to be operated on once. Both command forms are
fairly ugly.

The BSD make I used reports a version of 20200710 (accessible through
the MAKE_VERSION Makefile variable). The sed on the system doesn't
report a version. Both came as part of FreeBSD 12.2 (the latest
release version).

These changes seem to work just fine on Ubuntu 18.04 (with GNU Make
4.1 and GNU sed 4.4).