### PR TITLE
src/mastodon-lib.c: fix `gcc-15` build (`bool` collision)

### DIFF
--- a/src/mastodon-lib.c
+++ b/src/mastodon-lib.c
@@ -2093,9 +2093,9 @@ static char *indent(int n)
 /**
  * Return a static yes or no string. No deallocation needed.
  */
-static char *yes_or_no(int bool)
+static char *yes_or_no(int b)
 {
-	return bool ? "yes" : "no";
+	return b ? "yes" : "no";
 }
 
 /**


### PR DESCRIPTION
Without the chnage `bitlbee-mastodon` fails the build on `gcc-15` as:

     mastodon-lib.c:2096:28: error: 'bool' cannot be used here
      2096 | static char *yes_or_no(int bool)
           |                            ^~~~

This happens because `gcc-15` switched to `c23` by default which defines a `bool` as builtin type.

The change avoids use of `bool` as an identifier.